### PR TITLE
Fix fl.Short() call in adaptflag to reflect breaking upstream API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Licence
 -------
 
     © 2015 Hugo Landau <hlandau@devever.net>    MIT License
+    © 2017 Google, Inc.
 
 [Licenced under the licence with SHA256 hash
 `fd80a26fbb3f644af1fa994134446702932968519797227e07a1368dea80f0bc`, a copy of

--- a/adaptflag/adaptflag.go
+++ b/adaptflag/adaptflag.go
@@ -224,7 +224,7 @@ func Adapt() {
 			fl = fl.PlaceHolder("\"\"")
 		}
 		if r, ok := shortFlags[dpn]; ok {
-			fl = fl.Short(byte(r))
+			fl = fl.Short(r)
 		}
 		fl.SetValue(info.Value)
 	})


### PR DESCRIPTION
Over in [kingpin commit ea545afe29292738d692fa467690a9a34f61deaa](https://github.com/alecthomas/kingpin/commit/ea545afe29292738d692fa467690a9a34f61deaa) the `flag.Short()` method was changed to accept runes instead of bytes. This change removes the manual cast from adaptflag.

Without this change **neither easyconfig nor any of its' dependees cannot build**, as the kingpin library changed this without an API version bump.